### PR TITLE
feat: add mcp() hook with rails-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 
 ## Summary
 
-TODO: Add a short summary of this module.
+p6df module for Ruby on Rails: VSCode extensions and MCP server
+(`rails-mcp-server` via brew) for AI-driven Rails development.
 
 ## Contributing
 
@@ -36,6 +37,7 @@ TODO: Add a short summary of this module.
 ##### p6df-rails/init.zsh
 
 - `p6df::modules::rails::deps()`
+- `p6df::modules::rails::mcp()`
 - `p6df::modules::rails::vscodes()`
 
 ## Hierarchy

--- a/init.zsh
+++ b/init.zsh
@@ -26,3 +26,17 @@ p6df::modules::rails::vscodes() {
 
   p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6df::modules::rails::mcp()
+#
+#>
+######################################################################
+p6df::modules::rails::mcp() {
+
+  p6df::core::homebrew::cli::brew::install rails-mcp-server
+
+  p6_return_void
+}


### PR DESCRIPTION
## Summary
- Adds `p6df::modules::rails::mcp()` installing `rails-mcp-server` via brew
- Regenerated README with updated function list
- Restored Summary section

## Test plan
- [ ] `p6df::modules::rails::mcp()` installs `rails-mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)