### PR TITLE
fix(rails): use single-quoted variables in profile::mod (deferred eval)

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -57,5 +57,5 @@ p6df::modules::rails::mcp() {
 ######################################################################
 p6df::modules::rails::profile::mod() {
 
-  p6_return_words 'rails' "$RAILS_ENV"
+  p6_return_words 'rails' '$RAILS_ENV'
 }


### PR DESCRIPTION
**What:** Restore single-quoted variables in profile::mod p6_return_words calls

**Why:** Variables are intentionally single-quoted; eval happens later via p6_return_words machinery. The SC2016 fix incorrectly expanded them at call time.

**Test plan:** Build CI passes

**Dependencies:** None